### PR TITLE
default conf name to prova.conf

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,11 +34,11 @@ import (
 )
 
 const (
-	defaultConfigFilename        = "btcd.conf"
+	defaultConfigFilename        = "prova.conf"
 	defaultDataDirname           = "data"
 	defaultLogLevel              = "info"
 	defaultLogDirname            = "logs"
-	defaultLogFilename           = "btcd.log"
+	defaultLogFilename           = "prova.log"
 	defaultMaxPeers              = 125
 	defaultBanDuration           = time.Hour * 24
 	defaultBanThreshold          = 100


### PR DESCRIPTION
provactl threw errors at me saying prova.conf doesn't exist... turns out it was btcd.conf.